### PR TITLE
Rep 481 extended env for test systems

### DIFF
--- a/.env
+++ b/.env
@@ -1,13 +1,36 @@
-DB_PORT=8184
+# Mir Instance
+
+# general
+NAME=slavdok
+BASEDIR=/mcr/$NAME
+USER=mcr$NAME
+
+# mir
+MIR_VERSION=2020.06.x
+APP_CONTEXT=slavdok
+MIR_HOME=./mir-home/
+MIR_DATA=./mir-data/
+MIR_CLI=
+MIR_WEBAPP=
+
+MIR_PORT=18031
+MIR_AJPPORT=18032
+MIR_SPORT=
+
+# database
+POSTGRES_VERSION=12
+DB_PORT=18033
 DB_USER=postgresql
+DB_NAME=mir
 DB_PASSWORD=postgresqlpassword
 DB_DATA=./postgres-data/
 
-APP_CONTEXT=mir
-MIR_HTTP=8181
-MIR_AJP=8182
-MIR_HOME=./mir-home/
-MIR_DATA=./mir-data/
-
-SOLR_HTTP=8183
+# solr
+SOLR_VERSION=master
+SOLR_CORE=mir
+SOLR_CLASSIFICATION_CORE=mir-classifications
+SOLR_PORT=18034
 SOLR_DATA=./solr-data/
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# default data dirs
+mir-data/
+mir-home/
+postgres-data/
+solr-data/
+
 mir-docker-compose.iml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,35 +2,38 @@ version: '3.1'
 
 services:
   db:
-    image: postgres:12
+    container_name: ${NAME}-db
+    image: postgres:${POSTGRES_VERSION}
     restart: always
     environment:
      - POSTGRES_USER=${DB_USER}
      - POSTGRES_PASSWORD=${DB_PASSWORD}
-     - POSTGRES_DB=mir
+     - POSTGRES_DB=${DB_NAME}
     volumes:
     - ${DB_DATA}:/var/lib/postgresql/data/
     ports:
     - ${DB_PORT}:5432
   solr:
-    image: vzgreposis/mir-solr:master
+    container_name: ${NAME}-solr
+    image: vzgreposis/mir-solr:${SOLR_VERSION}
     restart: always
     volumes:
     - ${SOLR_DATA}:/var/solr-data
     ports:
-    - ${SOLR_HTTP}:8983
+    - ${SOLR_PORT}:8983
   mir:
-    image: vzgreposis/mir:2020.06.x
+    container_name: ${NAME}-mir
+    image: vzgreposis/mir:${MIR_VERSION}
     restart: always
     environment:
     - APP_CONTEXT=${APP_CONTEXT}
     - JDBC_NAME=${DB_USER}
     - JDBC_PASSWORD=${DB_PASSWORD}
     - JDBC_DRIVER=org.postgresql.Driver
-    - JDBC_URL=jdbc:postgresql://db:5432/mir
+    - JDBC_URL=jdbc:postgresql://db:5432/${DB_NAME}
     - SOLR_URL=http://solr:8983
-    - SOLR_CORE=mir
-    - SOLR_CLASSIFICATION_CORE=mir-classifications
+    - SOLR_CORE=${SOLR_CORE}
+    - SOLR_CLASSIFICATION_CORE=${SOLR_CLASSIFICATION_CORE}
     volumes:
     - ${MIR_HOME}:/mcr/home/
     - ${MIR_DATA}:/mcr/data/
@@ -38,5 +41,5 @@ services:
       - db
       - solr
     ports:
-      - ${MIR_HTTP}:8080
-      - ${MIR_AJP}:8009
+      - ${MIR_PORT}:8080
+      - ${MIR_AJPPORT}:8009


### PR DESCRIPTION
I've extended the usage of variables in the docker-compose file in order to configure our docker instances only by the .env file so that we do not have to modify the compose file for every mir instance on our test system. 